### PR TITLE
updates bluemix-settings.js

### DIFF
--- a/bluemix-settings.js
+++ b/bluemix-settings.js
@@ -24,7 +24,7 @@ var VCAP_APPLICATION = JSON.parse(process.env.VCAP_APPLICATION);
 var VCAP_SERVICES = JSON.parse(process.env.VCAP_SERVICES);
 
 var settings = module.exports = {
-    uiPort: process.env.VCAP_APP_PORT || 1880,
+    uiPort: process.env.PORT || 1880,
     mqttReconnectTime: 15000,
     serialReconnectTime: 15000,
     debugMaxLength: 1000,


### PR DESCRIPTION
VCAP_APP_PORT is deprecated and needs to replaced by PORT for compatibility with Cloud Foundry diego cells